### PR TITLE
Sort file names before generating cue file

### DIFF
--- a/code.js
+++ b/code.js
@@ -37,7 +37,7 @@ $(function() {
 function extractFilenames(fileList) {
   return $.makeArray(fileList).map(function(file) {
     return file.name
-  })
+  }).sort()
 }
 
 function filenamesToCue(fileNames) {


### PR DESCRIPTION
Why warn people about track order if it can be fixed in code? This might not solve all cases but it helped me.